### PR TITLE
Decouple `TcpStream` into read/write handles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 
 [dependencies]
 rand = "0.8.3"
+libc = "0.2"

--- a/src/server.rs
+++ b/src/server.rs
@@ -340,8 +340,8 @@ impl RtmpServer {
             media_stream.clients.iter_mut().for_each(|client| {
                 // SAFETY: Both streams are valid TcpStream and thus have valid file descriptors.
                 // Passing them to libc stat() function is fine.
-                if unsafe { get_fd_stat(client.stream.as_raw_fd()) }
-                    == unsafe { get_fd_stat(self.message_stream.as_raw_fd()) }
+                if dbg!(unsafe { get_fd_stat(client.stream.as_raw_fd()) })
+                    == dbg!(unsafe { get_fd_stat(self.message_stream.as_raw_fd()) })
                 {
                     client.paused = pause;
                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,7 +3,6 @@ use std::io::Cursor;
 use std::net::TcpStream;
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use crate::amf::*;
 use crate::error::{Error, Result};
@@ -12,12 +11,12 @@ use crate::utils::*;
 
 #[derive(Debug)]
 pub struct RtmpClient {
-    stream: Arc<Mutex<RtmpMessageStream<TcpStream>>>,
+    stream: RtmpMessageStream,
     paused: bool,
 }
 
 impl RtmpClient {
-    fn new(stream: Arc<Mutex<RtmpMessageStream<TcpStream>>>) -> Self {
+    fn new(stream: RtmpMessageStream) -> Self {
         Self {
             stream,
             paused: false,
@@ -47,7 +46,7 @@ impl DerefMut for RtmpMediaStream {
 }
 
 pub struct RtmpServer {
-    message_stream: Arc<Mutex<RtmpMessageStream<TcpStream>>>,
+    message_stream: RtmpMessageStream,
     media_streams: Arc<Mutex<HashMap<String, RtmpMediaStream>>>,
     stream_name: String,
 }
@@ -78,14 +77,14 @@ impl RtmpMediaStream {
     fn broadcast(&mut self, timestamp: u32, type_id: u8, message: &Message) {
         let offline: Vec<_> = self
             .clients
-            .iter()
+            .iter_mut()
             .enumerate()
             .map(|(i, client)| {
                 if client.paused {
                     return None;
                 }
-                let stream = &mut *client.stream.lock().unwrap();
-                if stream
+                if client
+                    .stream
                     .send_message(
                         3,
                         message.header.message_stream_id,
@@ -117,8 +116,7 @@ impl RtmpServer {
         assert_eq!(transaction_id, 1_f64);
         let cmd_object = decode_amf_object(&mut reader, true)?;
         eprintln!("cmd_object = {:?}", cmd_object);
-        let stream = &mut *self.message_stream.lock().unwrap();
-        stream.send_message(
+        self.message_stream.send_message(
             RTMP_PROTOCOL_CONTROL_CHUNK_STREAM_ID,
             RTMP_PROTOCOL_CONTROL_MESSAGE_STREAM_ID,
             0,
@@ -127,7 +125,7 @@ impl RtmpServer {
         )?;
         let mut buffer = Vec::from(1048576_u32.to_be_bytes());
         // Set window acknowledgement size.
-        stream.send_message(
+        self.message_stream.send_message(
             RTMP_PROTOCOL_CONTROL_CHUNK_STREAM_ID,
             RTMP_PROTOCOL_CONTROL_MESSAGE_STREAM_ID,
             0,
@@ -136,7 +134,7 @@ impl RtmpServer {
         )?;
         buffer.push(2);
         // Set peer bandwidth.
-        stream.send_message(
+        self.message_stream.send_message(
             RTMP_PROTOCOL_CONTROL_CHUNK_STREAM_ID,
             RTMP_PROTOCOL_CONTROL_MESSAGE_STREAM_ID,
             0,
@@ -144,7 +142,7 @@ impl RtmpServer {
             &buffer,
         )?;
         // Send user control message: Stream Begin.
-        stream.send_message(
+        self.message_stream.send_message(
             RTMP_PROTOCOL_CONTROL_CHUNK_STREAM_ID,
             RTMP_PROTOCOL_CONTROL_MESSAGE_STREAM_ID,
             0,
@@ -184,7 +182,7 @@ impl RtmpServer {
             AmfObject::Object(properties),
             AmfObject::Object(information),
         ]);
-        stream.send_message(
+        self.message_stream.send_message(
             3,
             RTMP_NET_CONNECTION_STREAM_ID,
             0,
@@ -210,7 +208,7 @@ impl RtmpServer {
         let cmd_object = decode_amf_message(&mut reader)?;
         match cmd_object {
             AmfObject::Object(_) | AmfObject::Null => {
-                self.message_stream.lock().unwrap().send_message(
+                self.message_stream.send_message(
                     3,
                     RTMP_NET_CONNECTION_STREAM_ID,
                     0,
@@ -263,19 +261,18 @@ impl RtmpServer {
             "stream_name = {}, start = {:?}, duration = {:?}, reset = {:?}",
             stream_name, start, duration, reset
         );
-        let stream = &mut *self.message_stream.lock().unwrap();
         // Set chunk size.
-        stream.send_message(
+        self.message_stream.send_message(
             RTMP_PROTOCOL_CONTROL_CHUNK_STREAM_ID,
             RTMP_PROTOCOL_CONTROL_MESSAGE_STREAM_ID,
             0,
             RTMP_SET_CHUNK_SIZE,
             &(0x7FFFFFFF_u32).to_be_bytes(),
         )?;
-        stream.max_chunk_size_write = 0x7FFFFFFF;
+        self.message_stream.max_chunk_size_write = 0x7FFFFFFF;
 
         // Send user control message: Stream Begin.
-        stream.send_message(
+        self.message_stream.send_message(
             RTMP_PROTOCOL_CONTROL_CHUNK_STREAM_ID,
             RTMP_PROTOCOL_CONTROL_MESSAGE_STREAM_ID,
             0,
@@ -283,14 +280,14 @@ impl RtmpServer {
             &[0x0; 6],
         )?;
 
-        stream.send_message(
+        self.message_stream.send_message(
             3,
             RTMP_NET_CONNECTION_STREAM_ID,
             0,
             RTMP_COMMAND_MESSAGE_AMF0,
             &Self::on_status("NetStream.Play.Reset"),
         )?;
-        stream.send_message(
+        self.message_stream.send_message(
             3,
             RTMP_NET_CONNECTION_STREAM_ID,
             0,
@@ -298,7 +295,7 @@ impl RtmpServer {
             &Self::on_status("NetStream.Play.Start"),
         )?;
         // XXX: Unknown message
-        stream.send_message(
+        self.message_stream.send_message(
             3,
             RTMP_NET_CONNECTION_STREAM_ID,
             0,
@@ -309,7 +306,8 @@ impl RtmpServer {
                 AmfObject::Boolean(true),
             ]),
         )?;
-        stream.set_read_timeout(Duration::from_micros(1));
+        // self.message_stream
+        //     .set_read_timeout(Duration::from_micros(1));
         let media_streams = &mut *self.media_streams.lock().unwrap();
         let media_streams = media_streams
             .entry(stream_name.clone())
@@ -317,7 +315,7 @@ impl RtmpServer {
 
         // Stream has already begun, send metadata first.
         if let Some(ref metadata) = media_streams.metadata {
-            stream.send_message(
+            self.message_stream.send_message(
                 3,
                 metadata.header.message_stream_id,
                 metadata.header.timestamp,
@@ -325,7 +323,7 @@ impl RtmpServer {
                 &metadata.message,
             )?;
         }
-        media_streams.push(RtmpClient::new(Arc::clone(&self.message_stream)));
+        media_streams.push(RtmpClient::new(self.message_stream.decouple()));
         self.stream_name = stream_name;
         Ok(())
     }
@@ -340,12 +338,16 @@ impl RtmpServer {
         let media_streams = &mut *self.media_streams.lock().unwrap();
         if let Some(media_stream) = media_streams.get_mut(&self.stream_name) {
             media_stream.clients.iter_mut().for_each(|client| {
-                if Arc::ptr_eq(&client.stream, &self.message_stream) {
+                // SAFETY: Both streams are valid TcpStream and thus have valid file descriptors.
+                // Passing them to libc stat() function is fine.
+                if unsafe { get_fd_stat(client.stream.as_raw_fd()) }
+                    == unsafe { get_fd_stat(self.message_stream.as_raw_fd()) }
+                {
                     client.paused = pause;
                 }
             });
         }
-        self.message_stream.lock().unwrap().send_message(
+        self.message_stream.send_message(
             3,
             RTMP_NET_CONNECTION_STREAM_ID,
             0,
@@ -375,7 +377,7 @@ impl RtmpServer {
             entry.published = true;
             "NetStream.Publish.Start"
         };
-        self.message_stream.lock().unwrap().send_message(
+        self.message_stream.send_message(
             3,
             RTMP_NET_CONNECTION_STREAM_ID,
             0,
@@ -447,8 +449,7 @@ impl RtmpServer {
         assert_eq!(message.header.message_length, 4);
         let mut buffer = [0x0; 4];
         buffer.copy_from_slice(&message.message);
-        self.message_stream.lock().unwrap().max_chunk_size_read =
-            u32::from_be_bytes(buffer) as usize;
+        self.message_stream.max_chunk_size_read = u32::from_be_bytes(buffer) as usize;
     }
 
     fn handle_window_ack_size(&mut self, message: Message) {
@@ -500,8 +501,9 @@ impl RtmpServer {
 
     fn handle_abort_message(&mut self, message: Message) -> Result<()> {
         let chunk_stream_id = read_u32(&mut Cursor::new(message.message)).map_err(Error::Io)?;
-        let stream = &mut *self.message_stream.lock().unwrap();
-        stream.channels.remove(&(chunk_stream_id as u16));
+        self.message_stream
+            .channels
+            .remove(&(chunk_stream_id as u16));
         Ok(())
     }
 
@@ -550,9 +552,9 @@ impl RtmpServer {
     }
 
     pub fn serve(&mut self) -> Result<()> {
-        self.message_stream.lock().unwrap().handle_handshake()?;
+        self.message_stream.handle_handshake()?;
         loop {
-            let message = self.message_stream.lock().unwrap().read_message();
+            let message = self.message_stream.read_message();
             match message {
                 Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::WouldBlock => {}
                 Ok(None) => {}
@@ -577,7 +579,7 @@ impl RtmpServer {
         media_streams: Arc<Mutex<HashMap<String, RtmpMediaStream>>>,
     ) -> RtmpServer {
         RtmpServer {
-            message_stream: Arc::new(Mutex::new(RtmpMessageStream::new(stream))),
+            message_stream: RtmpMessageStream::new(stream),
             media_streams,
             stream_name: String::new(),
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -42,7 +42,6 @@ pub fn read_buffer_sized<R: Read, const N: usize>(reader: &mut R) -> io::Result<
 }
 
 pub unsafe fn get_fd_stat(fd: RawFd) -> (libc::dev_t, libc::ino_t) {
-    eprintln!("fd = {}", fd);
     let mut stat: libc::stat = std::mem::zeroed();
     let stat_ptr: *mut libc::stat = &mut stat;
     libc::fstat(fd, stat_ptr);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,11 +41,12 @@ pub fn read_buffer_sized<R: Read, const N: usize>(reader: &mut R) -> io::Result<
     Ok(buffer)
 }
 
-pub unsafe fn get_fd_stat(fd: RawFd) -> (i32, i32) {
+pub unsafe fn get_fd_stat(fd: RawFd) -> (libc::dev_t, libc::ino_t) {
+    eprintln!("fd = {}", fd);
     let mut stat: libc::stat = std::mem::zeroed();
     let stat_ptr: *mut libc::stat = &mut stat;
     libc::fstat(fd, stat_ptr);
-    (stat.st_dev, stat.st_dev)
+    (stat.st_dev, stat.st_ino)
 }
 
 pub fn aggregate<T>(buffer: &[u8], is_little_endian: bool) -> T

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use std::io::{self, Read};
 use std::ops;
+use std::os::unix::io::RawFd;
 
 pub fn read_u8<R: Read>(reader: &mut R) -> io::Result<u8> {
     Ok(u8::from_be_bytes(read_buffer_sized::<_, 1>(reader)?))
@@ -38,6 +39,13 @@ pub fn read_buffer_sized<R: Read, const N: usize>(reader: &mut R) -> io::Result<
     let mut buffer = [0x0; N];
     reader.read_exact(&mut buffer)?;
     Ok(buffer)
+}
+
+pub unsafe fn get_fd_stat(fd: RawFd) -> (i32, i32) {
+    let mut stat: libc::stat = std::mem::zeroed();
+    let stat_ptr: *mut libc::stat = &mut stat;
+    libc::fstat(fd, stat_ptr);
+    (stat.st_dev, stat.st_dev)
 }
 
 pub fn aggregate<T>(buffer: &[u8], is_little_endian: bool) -> T


### PR DESCRIPTION
There's still a MacOS-specific bug to be fixed.

Closes #3.